### PR TITLE
No longer generate binstubs on deploy

### DIFF
--- a/lib/viget/deployment/recipes.rb
+++ b/lib/viget/deployment/recipes.rb
@@ -1,7 +1,6 @@
 require 'viget/deployment/setup'
 
 require 'viget/deployment/recipes/core'
-require 'viget/deployment/recipes/bundler'
 require 'viget/deployment/recipes/configuration'
 require 'viget/deployment/recipes/database'
 require 'viget/deployment/recipes/slack_notification'

--- a/lib/viget/deployment/recipes/bundler.rb
+++ b/lib/viget/deployment/recipes/bundler.rb
@@ -1,3 +1,0 @@
-Capistrano::Configuration.instance.load do
-  set(:bundle_flags, '--deployment --quiet --binstubs')
-end


### PR DESCRIPTION
This resolves #8 -- tested this on the new VOA production environment and it seems to be working just fine.