### PR TITLE
Add cachemonster.php.erb template and file mapping

### DIFF
--- a/lib/tasks/configuration/craft.rb
+++ b/lib/tasks/configuration/craft.rb
@@ -12,8 +12,9 @@ module Configuration
 
     def configuration_file_mapping
       {
-        'config.yml.erb' => 'config/config.yml',
-        'db.php.erb'     => 'craft/config/db.php'
+        'config.yml.erb'       => 'config/config.yml',
+        'db.php.erb'           => 'craft/config/db.php',
+        'cachemonster.php.erb' => 'craft/config/cachemonster.php'
       }
     end
 

--- a/lib/viget/deployment/cms/configuration.rb
+++ b/lib/viget/deployment/cms/configuration.rb
@@ -2,7 +2,8 @@ require 'viget/deployment/shared/configuration'
 
 Capistrano::Configuration.instance.load do
 
-  after 'deploy:configuration:symlink', 'deploy:configuration:symlink_database_config'
+  after 'deploy:configuration:symlink',                 'deploy:configuration:symlink_database_config'
+  after 'deploy:configuration:symlink_database_config', 'deploy:configuration:symlink_cachemonster_config'
 
   namespace :deploy do
     namespace :configuration do
@@ -11,6 +12,15 @@ Capistrano::Configuration.instance.load do
         escaped_release = latest_release.to_s.shellescape
         link_name       = "#{escaped_release}/#{database_configuration_path}"
         target          = "#{shared_path}/config/#{File.basename(database_configuration_path)}"
+
+        run "rm -rf -- #{link_name}"
+        run "ln -s  -- #{target} #{link_name}"
+      end
+
+      task :symlink_cachemonster_config, :roles => :app, :except => {:no_release => true} do
+        escaped_release = latest_release.to_s.shellescape
+        link_name       = "#{escaped_release}/#{cachemonster_configuration_path}"
+        target          = "#{shared_path}/config/#{File.basename(cachemonster_configuration_path)}"
 
         run "rm -rf -- #{link_name}"
         run "ln -s  -- #{target} #{link_name}"

--- a/lib/viget/deployment/craft/core.rb
+++ b/lib/viget/deployment/craft/core.rb
@@ -10,10 +10,11 @@ Capistrano::Configuration.instance.load do
     'craft/storage'  => 'craft/storage'
   }
 
-  set :upload_paths,                ['public/uploads', 'craft/storage/userphotos']
-  set :system_paths,                ['craft/app', 'craft/config', 'craft/storage']
-  set :configuration_files,         ['config/config.yml', 'config/db.php']
-  set :database_configuration_path, 'craft/config/db.php'
+  set :upload_paths,                    ['public/uploads', 'craft/storage/userphotos']
+  set :system_paths,                    ['craft/app', 'craft/config', 'craft/storage']
+  set :configuration_files,             ['config/config.yml', 'config/db.php']
+  set :database_configuration_path,     'craft/config/db.php'
+  set :cachemonster_configuration_path, 'craft/config/cachemonster.php'
 
   set(:rake_environment) { "CRAFT_ENV=#{app_env}" }
 

--- a/lib/viget/deployment/version.rb
+++ b/lib/viget/deployment/version.rb
@@ -1,5 +1,5 @@
 module Viget
   module Deployment
-    VERSION = '1.2.1'
+    VERSION = '1.3.0'
   end
 end

--- a/templates/craft/cachemonster.php.erb
+++ b/templates/craft/cachemonster.php.erb
@@ -1,0 +1,18 @@
+<?php
+
+return array(
+    'cacheElementQueries' => true,
+    'enableTemplateCaching' => true,
+    'includeQueryString' => true,
+
+    'externalCachingService' => 'CloudFlare',
+    'externalCachingServiceSettings' => array(
+        'url' => CRAFT_SITE_URL,
+        'authEmail' => '<%= ask(" *     CacheMonster CloudFlare Auth Email: ") %>',
+        'authKey' => '<%= ask(" *     CacheMonster CloudFlare Auth Key: ") %>',
+        'zoneId' => '<%= ask(" *     CacheMonster CloudFlare Zone ID: ") %>'
+    ),
+
+    'enableCacheWarming' => false,
+    'excludeQueryStringsWhenWarming' => true,
+);


### PR DESCRIPTION
Allows capistrano to configure and copy the sample Cache Monster plugin settings when deploying

Bumped to version 1.3.0
