### PR TITLE
Provide ability to re-generate configuration files

### DIFF
--- a/lib/viget/deployment/version.rb
+++ b/lib/viget/deployment/version.rb
@@ -1,5 +1,5 @@
 module Viget
   module Deployment
-    VERSION = '1.2.2'
+    VERSION = '1.2.3'
   end
 end


### PR DESCRIPTION
Adds a `deploy:configuration:recreate`  deployment task to selectively recreate configuration files on the targeted server(s)